### PR TITLE
feat: NoResult 컴포넌트 추가 및 이벤트 당첨 결과 없을 경우 처리 로직 구현

### DIFF
--- a/apps/web/app/events/lucky-draw/_components/Pages/Result/NoResult.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Result/NoResult.tsx
@@ -1,0 +1,25 @@
+import { Column } from '@repo/ui/components/Layout'
+import { Text } from '@repo/ui/components/Text'
+import { Button } from '@repo/ui/components/Button'
+import { CLIENT_PATH } from '@/_constants/path'
+
+export const NoResult = () => (
+  <Column className={'h-full'}>
+    <div className='my-auto'>
+      <Text variant={'title1'} className={'text-center text-gray-300'}>
+        아직 발표된 당첨 결과 없어요!
+      </Text>
+      <Text variant={'body1'} className={'text-center text-gray-200'}>
+        맛집을 등록하고 행운의 주인공이 되어보세요!
+      </Text>
+    </div>
+    <Button
+      as={'a'}
+      href={CLIENT_PATH.PLACE_NEW}
+      size={'medium'}
+      className={'w-full'}
+    >
+      맛집 등록하러 가기
+    </Button>
+  </Column>
+)

--- a/apps/web/app/events/lucky-draw/_components/Pages/Result/Result.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Result/Result.tsx
@@ -10,14 +10,14 @@ import { Column } from '@repo/ui/components/Layout'
 import { LottoBalls } from '../../LottoBalls'
 import { ParticipationStatus } from '../../ParticipationStatus'
 import { ResultModal } from './ResultModal'
+import { NoResult } from './NoResult'
 
 export const Result = () => {
   const [isRunning, setIsRunning] = useState(false)
   const { isOpen, onOpen, onOpenChange } = useDisclosure()
   const { data } = useSuspenseQuery(useEventQueries.result())
 
-  // Todo: 이전 이벤트 없을 경우 화면 구현
-  if (!data) return null
+  if (!data) return <NoResult />
 
   const { isWinner, participantsCount, usedTicketsCount } = data
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #46 

## 📝작업 내용

이전 이벤트(당첨 결과)가 없는 경우(처음 이벤트 오픈했을 때) 지면 추가


### 스크린샷 (선택)
<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/b888ee89-80b5-4879-9154-0c28a1666eee" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 이벤트 > 럭키드로우 결과 화면에 빈 상태 UI를 추가했습니다. 결과가 없을 때 명확한 안내 메시지와 설명을 표시합니다.
  - 전체 폭의 액션 버튼을 제공해 사용자가 즉시 새로운 장소 추가 페이지로 이동할 수 있습니다.
  - 기존에는 데이터가 없을 경우 화면에 아무것도 표시되지 않았으나, 이제 사용 흐름을 유지하며 다음 단계로 자연스럽게 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->