### PR TITLE
fix: 모바일과 Safari에서 CSS drop-shadow가 제대로 작동하지 않는 문제 개선

### DIFF
--- a/packages/ui/src/components/Icon/assets/icons/mapMarker.tsx
+++ b/packages/ui/src/components/Icon/assets/icons/mapMarker.tsx
@@ -14,10 +14,27 @@ export const MapMarker = ({
     xmlns='http://www.w3.org/2000/svg'
     {...props}
   >
+    <defs>
+      <filter
+        id='map-marker-shadow'
+        x='-30%'
+        y='-30%'
+        width='160%'
+        height='160%'
+      >
+        <feDropShadow
+          dx='0'
+          dy='2'
+          stdDeviation='2'
+          floodColor='#000000'
+          floodOpacity='0.5'
+        />
+      </filter>
+    </defs>
     <path
       d='M46.5 22C46.5 30.1938 35.5312 44.7813 30.7219 50.8C29.5687 52.2344 27.4313 52.2344 26.2781 50.8C21.4688 44.7813 10.5 30.1938 10.5 22C10.5 12.0625 18.5625 4 28.5 4C38.4375 4 46.5 12.0625 46.5 22Z'
       fill={color || '#FEFCF9'}
-      style={{ filter: 'drop-shadow(0px 2px 2px rgba(0,0,0,0.5))' }}
+      filter='url(#map-marker-shadow)'
     />
   </svg>
 )


### PR DESCRIPTION
## #️⃣연관된 이슈

- #56 

## 📝작업 내용
- 모바일과 Safari에서 CSS drop-shadow가 제대로 작동하지 않는 문제
=> CSS filter 대신 SVG의 네이티브 <filter> 태그를 사용

### 스크린샷 (선택)
#### 변경 전
<img width="1000" height="2062" alt="image" src="https://github.com/user-attachments/assets/c6ce9c80-2f47-45b7-91c2-aad8db812cef" />

#### 변경 후
<img width="1000" height="2062" alt="image" src="https://github.com/user-attachments/assets/7e576955-d514-4c44-8da5-0fa6afa39299" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- 지도 마커 아이콘의 그림자 표현을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->