### PR TITLE
Refactor/#79 Participation 컴포넌트 추상화 레벨 개선 및 구조 변경

### DIFF
--- a/apps/web/app/events/lucky-draw/_components/Pages/Participation/Participation.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Participation/Participation.tsx
@@ -4,11 +4,12 @@ import { useDisclosure } from '@heroui/react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useEventQueries } from '@/_apis/queries/event'
 import { Column } from '@repo/ui/components/Layout'
-import { Button } from '@repo/ui/components/Button'
 import { ParticipationModal } from './ParticipationModal'
 import { ParticipationCountdown } from './ParticipationCountdown'
+import { Text } from '@repo/ui/components/Text'
 import { ParticipationPrize } from './ParticipationPrize'
-import { RemainingTickets } from './RemainingTickets'
+import { ParticipationAction } from './ParticipationAction'
+import { ParticipationStatus } from '@/events/lucky-draw/_components/ParticipationStatus'
 
 export const Participation = () => {
   const { isOpen, onOpen, onOpenChange } = useDisclosure()
@@ -26,21 +27,35 @@ export const Participation = () => {
   return (
     <>
       <Column className={'mt-10 flex-1 items-center gap-10'}>
-        <ParticipationCountdown eventEndDate={eventEndDate} />
-        <ParticipationPrize
-          description={prize.description}
-          totalWinnersCount={totalWinnersCount}
-          imageUrl={prize.imageUrl}
-          participantsCount={participantsCount}
-          usedTicketsCount={usedTicketsCount}
-        />
-        <Column className={'mt-auto w-full gap-2.5'}>
-          <RemainingTickets remainingTicketsCount={remainingTicketsCount} />
-          <Button size={'medium'} className={'w-full'} onClick={onOpen}>
-            응모하기
-          </Button>
+        <Column className={'items-center gap-1'}>
+          <Text fontSize={'sm'} fontWeight={'semibold'}>
+            응모 종료까지 남은 시간
+          </Text>
+          <ParticipationCountdown eventEndDate={eventEndDate} />
         </Column>
+        <Column className={'items-center gap-3'}>
+          <Text fontSize={'2xl'} fontWeight={'bold'}>
+            이번주 행운의 상품은?
+          </Text>
+          <Column className={'items-center gap-5'}>
+            <ParticipationPrize
+              imageUrl={prize.imageUrl}
+              description={prize.description}
+              totalWinnersCount={totalWinnersCount}
+            />
+            <ParticipationStatus
+              participantsCount={participantsCount}
+              usedTicketsCount={usedTicketsCount}
+            />
+          </Column>
+        </Column>
+        <ParticipationAction
+          onParticipate={onOpen}
+          remainingTicketsCount={remainingTicketsCount}
+        />
       </Column>
+
+      {/*응모하기 버튼 클릭 시 응모권 갯수 선택 모달*/}
       <ParticipationModal
         isOpen={isOpen}
         onOpenChange={onOpenChange}

--- a/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationAction.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationAction.tsx
@@ -1,0 +1,34 @@
+import { Icon } from '@repo/ui/components/Icon'
+import { Column, Flex } from '@repo/ui/components/Layout'
+import { Button } from '@repo/ui/components/Button'
+import { Text } from '@repo/ui/components/Text'
+
+type Props = {
+  remainingTicketsCount: number
+  onParticipate: () => void
+}
+
+export const ParticipationAction = ({
+  remainingTicketsCount,
+  onParticipate,
+}: Props) => {
+  return (
+    <Column className={'mt-auto w-full gap-2.5'}>
+      <Flex className={'justify-center gap-1.5'}>
+        <Icon type={'ticket'} />
+        <Text variant={'body1'}>보유 응모권</Text>
+        <Text fontSize={'sm'} fontWeight={'semibold'} className={'text-yellow'}>
+          {remainingTicketsCount}장
+        </Text>
+      </Flex>
+      <Button
+        size={'medium'}
+        className={'w-full'}
+        onClick={onParticipate}
+        disabled={!remainingTicketsCount}
+      >
+        응모하기
+      </Button>
+    </Column>
+  )
+}

--- a/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationCountdown.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationCountdown.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Column } from '@repo/ui/components/Layout'
 import { Text } from '@repo/ui/components/Text'
 import { formatRemainingTime } from '@/events/lucky-draw/_utils/formatRemainingTime'
 
@@ -28,13 +27,8 @@ export const ParticipationCountdown = ({
   }, [eventEndDate])
 
   return (
-    <Column className={'items-center gap-1'}>
-      <Text fontSize={'sm'} fontWeight={'semibold'}>
-        응모 종료까지 남은 시간
-      </Text>
-      <Text fontSize={'2xl'} fontWeight={'semibold'} className={'text-yellow'}>
-        {remainingTime}
-      </Text>
-    </Column>
+    <Text fontSize={'2xl'} fontWeight={'semibold'} className={'text-yellow'}>
+      {remainingTime}
+    </Text>
   )
 }

--- a/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationPrize.tsx
+++ b/apps/web/app/events/lucky-draw/_components/Pages/Participation/ParticipationPrize.tsx
@@ -1,37 +1,23 @@
 import Image from 'next/image'
 import { Text } from '@repo/ui/components/Text'
 import { Column } from '@repo/ui/components/Layout'
-import { ParticipationStatus } from '../../ParticipationStatus'
 
 type Props = {
+  imageUrl: string
   description: string
   totalWinnersCount: number
-  imageUrl: string
-  participantsCount: number
-  usedTicketsCount: number
 }
 
 export const ParticipationPrize = ({
+  imageUrl,
   description,
   totalWinnersCount,
-  imageUrl,
-  participantsCount,
-  usedTicketsCount,
 }: Props) => (
-  <Column className={'items-center gap-3'}>
-    <Text fontSize={'2xl'} fontWeight={'bold'}>
-      이번주 행운의 상품은?
-    </Text>
-    <Column className={'items-center gap-5'}>
-      <Column className={'items-center'}>
-        <Text variant={'title3'}>{description}</Text>
-        <Text variant={'title3'}>총 당첨자: {totalWinnersCount}명</Text>
-      </Column>
-      <Image src={imageUrl} alt={'상품 이미지'} width={200} height={200} />
-      <ParticipationStatus
-        participantsCount={participantsCount}
-        usedTicketsCount={usedTicketsCount}
-      />
+  <>
+    <Column className={'items-center'}>
+      <Text variant={'title3'}>{description}</Text>
+      <Text variant={'title3'}>총 당첨자: {totalWinnersCount}명</Text>
     </Column>
-  </Column>
+    <Image src={imageUrl} alt={'상품 이미지'} width={200} height={200} />
+  </>
 )


### PR DESCRIPTION
## #️⃣연관된 이슈

- #79 

## 📝작업 내용
`Participation` 관련 컴포넌트들의 추상화 레벨을 통일하고 관심사를 명확히 분리하기 위한 리팩토링을 진행했습니다.

### 1. ParticipationPrize와 ParticipationStatus 분리
**변경 배경:** 
기존 ParticipationPrize 내부에는 상품 정보뿐만 아니라 '참여 현황(Status)'까지 포함되어 있어, 컴포넌트의 책임이 불분명했습니다.

**작업 내용:** 
ParticipationStatus를 별도 컴포넌트로 분리하고, 부모 컴포넌트에서 조합하여 사용하도록 구조를 변경했습니다. 이를 통해 각 컴포넌트가 하나의 역할만 수행하도록 개선했습니다.

### 2. ParticipationAction 컴포넌트 분리
**변경 배경:** 
Participation 컴포넌트 내부에서 상단부는 컴포넌트 단위(Countdown, Prize)로 추상화되어 있는 반면, 하단 액션 영역(티켓 정보 + 버튼)은 구체적인 태그(Flex, Button)가 노출되어 있어 추상화 레벨이 혼재되어 있었습니다.

작업 내용: 하단 액션 UI를 ParticipationAction 컴포넌트로 추출하여, Participation 컴포넌트가 전체적인 레이아웃 배치(Orchestration)에만 집중하도록 레벨을 맞췄습니다.

### 3. 섹션 제목(Text)의 위치 이동 (과도한 추상화 방지)
**고민:** 
기존코드는 추상화의 단일 레벨을 위해 섹션의 제목까지 자식 컴포넌트 내부로 숨기는 추상화를 사용했으나, 직관성을 해치고 단순 텍스트 수정을 위해 파일을 열어봐야 하는 번거로움을 유발한다고 판단했습니다.

**결정:** 
섹션 제목은 부모 컴포넌트(Participation)에 그대로 두어, 코드만 보고도 페이지의 텍스트를 통해 전체 구조(시간 -> 상품 -> 액션)를 한눈에 파악할 수 있도록 가독성과 실용성을 챙겼습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 행운의 드로우 참여 페이지 UI 완전 개편: 카운트다운, 상품 정보, 응모 버튼이 명확하게 구분된 레이아웃으로 재구성되었습니다.
* 상품 정보가 전용 영역에서 더욱 시각적으로 표시됩니다.

## 개선 사항
* 남은 시간 표시가 단순화되어 더 명확하게 확인 가능합니다.
* 응모 버튼이 보유한 티켓 수에 따라 자동으로 활성화/비활성화됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->