### PR TITLE
fix: 배너 컴포넌트 초기 렌더링 시 레이아웃 흔들림(화면 안정성 개선)

### DIFF
--- a/packages/ui/src/components/Banner/Banner.tsx
+++ b/packages/ui/src/components/Banner/Banner.tsx
@@ -43,7 +43,7 @@ export const Banner = ({
   const [loaded, setLoaded] = useState(false)
   const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>(
     {
-      loop: true,
+      loop: contents.length > 1,
       initial: 0,
       slideChanged(slider) {
         setCurrentSlide(slider.track.details.rel)
@@ -101,7 +101,13 @@ export const Banner = ({
       style={{ minHeight }}
     >
       {contents.map((content, index) => (
-        <div key={index} className='keen-slider__slide bg-white'>
+        <div
+          key={index}
+          className={cn(
+            'keen-slider__slide bg-white',
+            !loaded && index !== 0 && 'hidden',
+          )}
+        >
           {content}
         </div>
       ))}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #86 

## 📝작업 내용
### 1. 배너 초기 렌더링 시 레이아웃 흔들림(CLS) 해결
**문제 상황:**
keen-slider 라이브러리는 자바스크립트가 실행되고 초기화(init)된 후에야 슬라이드 위치를 계산합니다. 이로 인해 JS 로딩 전(Hydration 이전)에는 contents들이 세로로 나열되었다가 제대로 확장 되며 레이아웃이 덜컥거리는 현상이 발생했습니다.
**해결 방법:**
JS가 로드되기 전에는 style를 활용하여 첫 번째 슬라이드만 노출하고, 나머지 슬라이드는 숨김(hidden) 처리하여 레이아웃을 고정했습니다.


### 스크린샷 (선택)
**적용 전**
<img width="307" height="1659" alt="image" src="https://github.com/user-attachments/assets/bc3a2f5d-a806-40f8-932b-a758b3f8a845" />


**적용 후**

<img width="307" height="1650" alt="image" src="https://github.com/user-attachments/assets/a91ca305-14ac-4904-8458-69407ca3e723" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 배너 슬라이더가 단일 항목일 때 루핑되지 않도록 수정
* 컴포넌트 로드 완료 전까지 첫 번째 슬라이드만 표시되도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->