### PR TITLE
Fix/#103 맛집 등록 시 Description 작성 중 포커스 밀림 에러 (리렌더링) 해결

### DIFF
--- a/apps/web/app/places/new/page.tsx
+++ b/apps/web/app/places/new/page.tsx
@@ -88,7 +88,7 @@ const PlaceNewPage = () => {
   // 엔터 클릭 시 폼 제출 방지
   const preventEnterKeySubmission = (e: KeyboardEvent) => {
     const target = e.target as HTMLElement
-    if (e.key === 'Enter' && target.tagName !== 'TEXTAREA') {
+    if (e.key === 'Enter' && target.tagName !== 'INPUT') {
       e.preventDefault()
     }
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #103 

## 📝작업 내용

맛집 등록(`PlaceNewPage`) 프로세스 중, 설명(`Description`) 입력 단계에서 첫 텍스트 입력 시 컴포넌트 전체 리렌더링 후 재포커스되는 문제를 해결했습니다.


### 1. 엔터 키 입력 시 폼 제출 방지 로직 추가
**문제 원인**
1. 이전 단계(장소 검색 등)의 `input` 필드에서 Enter 키를 누르면 브라우저 기본 동작에 의해 **암시적 폼 제출(Implicit Submission)**이 시도됨.
2. 필수 값 누락으로 제출은 실패하지만, `react-hook-form`의 내부 상태가 `isSubmitted: true`로 변경됨.
3. 이에 따라 검증 모드(r`eValidateMode`)가 기본값인 `onChange`로 자동 전환됨.
4. `Description` 단계에서 글자를 하나 입력할 때마다 Zod 검증이 발생.

**해결 방안**
`<form>` 태그에 `onKeyDown` 핸들러를 추가하여 전역적으로 키보드 이벤트를 감지하도록 수정했습니다.
`TEXTAREA`를 제외한 모든 요소에서 Enter 키 입력 시 `e.preventDefault()`를 호출하여 폼 제출 동작을 차단했습니다.



### 스크린샷 (선택)
**수정 전 (에러 발생 영상)**

https://github.com/user-attachments/assets/39522402-e1b2-424f-85b4-ab06052e1846



> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 새 장소 추가 양식에서 Enter 키로 인한 의도치 않은 폼 제출이 방지되었습니다 — 이제 입력 필드(INPUT)에 포커스가 있을 때만 Enter로 제출됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->