### PR TITLE
Feat/#120 홈페이지(Home) SSG 카테고리 & CSR 랭킹 하이브리드 렌더링 구현

### DIFF
--- a/apps/web/app/(home)/_components/RankingSection/RankingListFetcher.tsx
+++ b/apps/web/app/(home)/_components/RankingSection/RankingListFetcher.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import type { RankingPlaceSort } from '@/_apis/schemas/place'
+import { useCampusStore } from '@/_store/campus'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { usePlaceQueries } from '@/_apis/queries/place'
+import { EmptyFallback } from '@/_components/EmptyFallback'
+import { PlaceListItem } from '@/_components/PlaceListItem'
+
+export const RankingListFetcher = ({
+  rankingPlaceSort,
+}: {
+  rankingPlaceSort: RankingPlaceSort
+}) => {
+  const { campus } = useCampusStore()
+  const { data: places } = useSuspenseQuery(
+    usePlaceQueries.byRanking(rankingPlaceSort, campus),
+  )
+
+  return (
+    <EmptyFallback
+      isEmpty={places.length === 0}
+      fallbackDescription={'아직 집계된 추천 맛집이 없습니다'}
+    >
+      <ul className={'px-3'}>
+        {places.map((place, index) => (
+          <PlaceListItem
+            key={place.placeId}
+            {...place}
+            showBorder={index !== places.length - 1}
+          />
+        ))}
+      </ul>
+    </EmptyFallback>
+  )
+}

--- a/apps/web/app/(home)/_components/RankingSection/RankingListFetcherClient.tsx
+++ b/apps/web/app/(home)/_components/RankingSection/RankingListFetcherClient.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { PlaceListItem } from '@/_components/PlaceListItem'
+
+export const RankingListFetcherClient = dynamic(
+  () =>
+    import('./RankingListFetcher').then((mod) => ({
+      default: mod.RankingListFetcher,
+    })),
+  {
+    ssr: false,
+    loading: () => <PlaceListItem.Skeleton />,
+  },
+)

--- a/apps/web/app/(home)/_components/RankingSection/RankingSection.tsx
+++ b/apps/web/app/(home)/_components/RankingSection/RankingSection.tsx
@@ -1,16 +1,11 @@
-'use client'
-
 import { Suspense } from 'react'
 import { ErrorBoundary } from '@suspensive/react'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { useCampusStore } from '@/_store/campus'
-import { usePlaceQueries } from '@/_apis/queries/place'
 import { Icon, IconType } from '@repo/ui/components/Icon'
 import type { RankingPlaceSort } from '@/_apis/schemas/place'
 import { Column, Flex } from '@repo/ui/components/Layout'
 import { PlaceListItem } from '@/_components/PlaceListItem'
 import { Text } from '@repo/ui/components/Text'
-import { EmptyFallback } from '@/_components/EmptyFallback'
+import { RankingListFetcherClient } from './RankingListFetcherClient'
 
 type Props = {
   title: string
@@ -29,38 +24,10 @@ export const RankingSection = ({ title, icon, rankingPlaceSort }: Props) => {
       </Flex>
       <ErrorBoundary fallback={<ErrorFallback />}>
         <Suspense fallback={<PlaceListItem.Skeleton />}>
-          <RankingListFetcher rankingPlaceSort={rankingPlaceSort} />
+          <RankingListFetcherClient rankingPlaceSort={rankingPlaceSort} />
         </Suspense>
       </ErrorBoundary>
     </Column>
-  )
-}
-
-const RankingListFetcher = ({
-  rankingPlaceSort,
-}: {
-  rankingPlaceSort: RankingPlaceSort
-}) => {
-  const { campus } = useCampusStore()
-  const { data: places } = useSuspenseQuery(
-    usePlaceQueries.byRanking(rankingPlaceSort, campus),
-  )
-
-  return (
-    <EmptyFallback
-      isEmpty={places.length === 0}
-      fallbackDescription={'아직 집계된 추천 맛집이 없습니다'}
-    >
-      <ul className={'px-3'}>
-        {places.map((place, index) => (
-          <PlaceListItem
-            key={place.placeId}
-            {...place}
-            showBorder={index !== places.length - 1}
-          />
-        ))}
-      </ul>
-    </EmptyFallback>
   )
 }
 

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -18,6 +18,8 @@ import {
   LuckyDrawBanner,
 } from './_components/eventBanners'
 
+export const dynamic = 'force-static'
+
 export default function Page() {
   return (
     <>

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -1,13 +1,11 @@
 import Link from 'next/link'
 import { CLIENT_PATH } from '@/_constants/path'
-import { useCategoryQueries } from '@/_apis/queries/category'
 import { Header } from '@repo/ui/components/Header'
 import { SearchBar } from '@repo/ui/components/SearchBar'
 import { Flex, VerticalScrollArea } from '@repo/ui/components/Layout'
 import { Icon } from '@repo/ui/components/Icon'
 import { Text } from '@repo/ui/components/Text'
 import { Divider } from '@repo/ui/components/Divider'
-import { HydrationBoundaryPage } from '@/_components/HydrationBoundaryPage'
 import { Carousel } from '@repo/ui/components/Carousel'
 import { Categories } from '@/_components/Categories'
 import { BottomNavigation } from '@/_components/BottomNavigation'
@@ -40,13 +38,7 @@ export default function Page() {
         className={'mx-5 mb-5'}
       />
       <VerticalScrollArea className={'gap-4'}>
-        <HydrationBoundaryPage
-          prefetch={async (queryClient) => {
-            await queryClient.prefetchQuery(useCategoryQueries.list())
-          }}
-        >
-          <Categories />
-        </HydrationBoundaryPage>
+        <Categories />
         <Carousel showIndicator={true}>
           <LuckyDrawBanner />
           <FoodSlotMachineBanner />

--- a/apps/web/app/_components/Categories/Categories.tsx
+++ b/apps/web/app/_components/Categories/Categories.tsx
@@ -1,12 +1,9 @@
-'use client'
-
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { useCategoryQueries } from '@/_apis/queries/category'
+import { getCategories } from '@/_apis/services/category'
 import { cn } from '@repo/ui/utils/cn'
 import { CategoryItem } from './CategoryItem'
 
-export const Categories = () => {
-  const { data: categories } = useSuspenseQuery(useCategoryQueries.list())
+export const Categories = async () => {
+  const categories = await getCategories()
 
   return (
     <div

--- a/apps/web/app/_lib/axiosInstance.ts
+++ b/apps/web/app/_lib/axiosInstance.ts
@@ -8,8 +8,26 @@ import { getToken } from '@/_apis/services/login'
 import { getCookie } from '@/_utils/getCookie'
 import { setCookie } from 'cookies-next'
 
+// 빌드 시점에만 직접 API 서버로, SSR/CSR에서는 rewrite 사용
+const getBaseURL = () => {
+  // 빌드 시점 감지: next build 실행 중에는 NEXT_PHASE가 'phase-production-build'
+  const isBuildTime =
+    typeof window === 'undefined' &&
+    process.env.NEXT_PHASE === 'phase-production-build'
+
+  if (isBuildTime) {
+    // 빌드 시에만 직접 API 서버로 연결
+    return (
+      process.env.NEXT_PUBLIC_API_URL_BUILD || process.env.NEXT_PUBLIC_API_URL
+    )
+  }
+
+  // SSR, CSR 모두 rewrite 사용
+  return process.env.NEXT_PUBLIC_API_URL
+}
+
 const axiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: getBaseURL(),
   headers: {
     'Content-Type': 'application/json',
   },

--- a/apps/web/app/_lib/axiosInstance.ts
+++ b/apps/web/app/_lib/axiosInstance.ts
@@ -8,22 +8,22 @@ import { getToken } from '@/_apis/services/login'
 import { getCookie } from '@/_utils/getCookie'
 import { setCookie } from 'cookies-next'
 
-// 빌드 시점에만 직접 API 서버로, SSR/CSR에서는 rewrite 사용
-const getBaseURL = () => {
-  // 빌드 시점 감지: next build 실행 중에는 NEXT_PHASE가 'phase-production-build'
-  const isBuildTime =
-    typeof window === 'undefined' &&
-    process.env.NEXT_PHASE === 'phase-production-build'
+const isServer = typeof window === 'undefined'
+const isBuildTime =
+  isServer && process.env.NEXT_PHASE === 'phase-production-build'
 
+/**
+ * 빌드 환경에 따른 API Base URL 결정
+ * - Build Time: 직접 API 서버 연결 (rewrite 미적용)
+ * - Runtime (SSR/CSR): Next.js rewrite 경유
+ */
+const getBaseURL = (): string => {
   if (isBuildTime) {
-    // 빌드 시에만 직접 API 서버로 연결
     return (
-      process.env.NEXT_PUBLIC_API_URL_BUILD || process.env.NEXT_PUBLIC_API_URL
+      process.env.NEXT_PUBLIC_API_URL_BUILD || process.env.NEXT_PUBLIC_API_URL!
     )
   }
-
-  // SSR, CSR 모두 rewrite 사용
-  return process.env.NEXT_PUBLIC_API_URL
+  return process.env.NEXT_PUBLIC_API_URL!
 }
 
 const axiosInstance = axios.create({
@@ -36,8 +36,9 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   async (config) => {
-    const token = await getCookie('accessToken')
+    if (isBuildTime) return config
 
+    const token = await getCookie('accessToken')
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -7,6 +7,8 @@ import { Column } from '@repo/ui/components/Layout'
 import { UserProfile } from '@/profile/_components/UserProfile'
 import { ProfileMenuItem } from '@/profile/_components/ProfileMenuItem'
 
+export const dynamic = 'force-dynamic'
+
 const Page = () => {
   return (
     <>

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
-  "globalEnv": ["NODE_ENV","NEXT_PUBLIC_API_URL", "NEXT_RUNTIME", "CI"],
+  "globalEnv": ["NODE_ENV", "NEXT_RUNTIME", "CI", "NEXT_PHASE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## #️⃣연관된 이슈

- #120

## 📝작업 내용
홈 페이지를 SSG로 최적화하면서 사용자별 실시간 데이터(랭킹)는 CSR로 처리하는 하이브리드 렌더링 전략을 구현했습니다

### 1. 홈 페이지 SSG 설정 
- export const dynamic = 'force-static' 추가하여 정적 생성 강제

### 2. Categories 섹션 SSG 구현
- React Query 기반 클라이언트 컴포넌트 → async/await 기반 서버 컴포넌트로 전환
- 빌드 타임에 카테고리 데이터를 HTML에 포함하여 초기 로딩 속도 개선
- 불필요한 HydrationBoundaryPage 제거

### 3. Ranking 섹션 CSR 구현
- RankingSection: 서버 컴포넌트로 UI 구조 담당 
- RankingListFetcher: 클라이언트 컴포넌트로 데이터 fetching 로직 분리 
- RankingListFetcherClient: next/dynamic의 ssr: false 옵션으로 클라이언트 전용 렌더링 
- 동적 import로 SSG 빌드 시 랭킹 섹션 생성 방지, 클라이언트에서만 실시간 데이터 조회

### 스크린샷 (선택)

빌드 결과물(index.html)에 카테고리 데이터가 포함된 모습 (랭킹 데이터는 미포함)
<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/ff628b63-3d4b-4442-b687-c15414201381" />


실제 동작

![Frame 46](https://github.com/user-attachments/assets/db1b0367-8eba-4669-a726-94f11fe64b33)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 랭킹 섹션에 새로운 데이터 로딩 컴포넌트 추가

* **Refactor**
  * 카테고리 데이터 페칭을 서버 사이드로 변경하여 성능 최적화
  * 랭킹 리스트 컴포넌트의 렌더링 구조 개선
  * API 기본 URL 처리 로직 강화

* **Chores**
  * 빌드 및 환경 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->